### PR TITLE
Update slog-term dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = "^1.0.79"
 serde_yaml = "^0.8.23"
 slog = { version = "^2.7.0", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "^2.7.0"
-slog-term = "^2.8.1"
+slog-term = "^2.9.0"
 slog-scope = "^4.4.0"
 structopt = { version = "^0.3.26", features = ["paw"] }
 tokio = { version = "^1.17.0", features = ["full"] }


### PR DESCRIPTION
* Bump slog-term to 2.9.0

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>