### PR TITLE
Update minimum supported rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ description = "A command line interface to interact with the ovhcloud api"
 version = "0.1.6"
 authors = ["Florentin Dubois <florentin.dubois@hey.com>"]
 edition = "2021"
+rust-version = "1.60.0"
+repository = "https://github.com/FlorentinDUBOIS/ovhctl"
 license = "MIT"
+keywords = ["OVHcloud", "rust", "cli"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
* Bump rust to 1.60.0 (stable)
* Set keywords and repository metadata

Signed-off-by: Florentin Dubois <florentin.dubois@clever-cloud.com>